### PR TITLE
Display Thermostat Mode Based on Difference Between Current and Target Temperature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
-  "displayName": "Homebridge Sleepme",
-  "name": "homebridge-sleepme",
+  "displayName": "Homebridge Sleepme-test",
+  "name": "homebridge-sleepme-test",
   "version": "0.1.7",
   "description": "HomeKit support for Sleepme Dock Pro devices via Homebridge",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
-  "displayName": "Homebridge Sleepme-test",
-  "name": "homebridge-sleepme-test",
+  "displayName": "Homebridge Sleepme",
+  "name": "homebridge-sleepme",
   "version": "0.1.7",
   "description": "HomeKit support for Sleepme Dock Pro devices via Homebridge",
   "license": "Apache-2.0",

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -9,19 +9,23 @@ type SleepmeContext = {
 };
 
 interface Mapper {
-  toHeatingCoolingState: (status: DeviceStatus) => 0 | 2;
+  toHeatingCoolingState: (status: DeviceStatus) => 0 | 1 | 2;
 }
 
 function newMapper(platform: SleepmePlatform): Mapper {
   const {Characteristic} = platform;
   return {
-    toHeatingCoolingState: (status: DeviceStatus): 0 | 2 => {
+    toHeatingCoolingState: (status: DeviceStatus): 0 | 1 | 2 => {
+      // If the device is off, return OFF state
       if (status.control.thermal_control_status === 'standby') {
         return Characteristic.CurrentHeatingCoolingState.OFF;
       }
       
-      // Determine if it's heating or cooling based on temperatures
-      if (status.control.current_temperature < status.control.target_temperature) {
+      // Compare current and target temperatures to determine heating or cooling
+      const currentTemp = status.status.water_temperature_c;
+      const targetTemp = status.control.set_temperature_c;
+      
+      if (targetTemp > currentTemp) {
         return Characteristic.CurrentHeatingCoolingState.HEAT;
       } else {
         return Characteristic.CurrentHeatingCoolingState.COOL;
@@ -30,6 +34,7 @@ function newMapper(platform: SleepmePlatform): Mapper {
   };
 }
 
+// Rest of the code remains exactly the same from here...
 class Option<T> {
   readonly value: T | null;
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -16,9 +16,16 @@ function newMapper(platform: SleepmePlatform): Mapper {
   const {Characteristic} = platform;
   return {
     toHeatingCoolingState: (status: DeviceStatus): 0 | 2 => {
-      return status.control.thermal_control_status === 'standby' ?
-        Characteristic.CurrentHeatingCoolingState.OFF :
-        Characteristic.CurrentHeatingCoolingState.COOL;
+      if (status.control.thermal_control_status === 'standby') {
+        return Characteristic.CurrentHeatingCoolingState.OFF;
+      }
+      
+      // Determine if it's heating or cooling based on temperatures
+      if (status.control.current_temperature < status.control.target_temperature) {
+        return Characteristic.CurrentHeatingCoolingState.HEAT;
+      } else {
+        return Characteristic.CurrentHeatingCoolingState.COOL;
+      }
     },
   };
 }


### PR DESCRIPTION
This PR implements code changes that compare the current and target temperature values to automatically display an appropriate thermostat mode in home app.

If the thermostat is OFF, or the dock is in standby, it will display as OFF mode.

If thermal control is ACTIVE, and If the target temperature is higher than the current temperature, it will show as being in HEAT mode. Otherwise, it wil show as being in COOL mode.

This clears issue #77 .

![IMG_4561](https://github.com/user-attachments/assets/0cf759bc-5c77-41ab-8429-fffc797fa8f5)
![IMG_4560](https://github.com/user-attachments/assets/0835f154-a7e0-4316-809d-7b0415894626)
